### PR TITLE
ci(actions): replace deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,16 +11,11 @@ inputs:
     required: false
     default: ${{ github.sha }}
     description: 'Commit hash, e.g. 59d2e89c36774ee3775050a437c290a6c1afb3db'
-outputs:
-  release_version:
-    description: 'The release version of Heroku deployment, e.g. 10'
-    value: ${{ steps.deploy-and-get-release-version.outputs.release_version }}
 
 runs:
   using: "composite"
   steps:
-    - id: deploy-and-get-release-version
-      run: python3 -m deploy_heroku
+    - run: python3 -m deploy_heroku
       shell: bash
       env:
         APP: ${{ inputs.heroku_app }}

--- a/deploy_heroku.py
+++ b/deploy_heroku.py
@@ -143,7 +143,6 @@ def main(heroku_app: str, heroku_api_key: str, git_commit_hash: str, json_event_
         raise RuntimeError("Heroku release command failed! See Heroku release logs for detailed information.")
 
     print(f"New release version is {latest_heroku_release.version}")
-    print(f"::set-output name=release_version::{latest_heroku_release.version}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replacing the deprecated set-output command as discussed in MD-6382. If I understand things correctly, a simple print() is no longer sufficient and we now need to use subprocess.run(). Do you also see it this way, @marns93? 