### PR TITLE
feat(action): simplify action by removing deployment type logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,4 @@ runs:
         APP: ${{ inputs.heroku_app }}
         API_KEY: ${{ inputs.heroku_api_key }}
         COMMIT_HASH: ${{ inputs.github_sha }}
-        JSON_EVENT_PATH: ${{ github.event_path }}
         PYTHONPATH: ${{ github.action_path }}


### PR DESCRIPTION
As discussed today. We don't need the deployment type in the payload.

What changed:
* Removed the payload and logic with deployment type
* We check the commit hash, if the commit for deployment is the active one on Heroku, if yes we trigger a release-retry
* Otherwise, we trigger a git push with `--force`